### PR TITLE
TMC_AWS_SECRET_MANAGER_ENABLED defaulted to true

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -24,7 +24,7 @@ logging:
 
 tmc:
   aws:
-    enabled: true
+    enabled: ${TMC_AWS_SECRET_MANAGER_ENABLED:true}
     secret-name: ${TMC_AWS_SECRET_MANAGER_NAME}
     region: ${TMC_AWS_REGION:${AWS_REGION:eu-west-2}}
 


### PR DESCRIPTION
feat: TMC_AWS_SECRET_MANAGER_ENABLED defaulted to true, to reuse in local application development;